### PR TITLE
update GitHub project name in setup url arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author='Serafeim Papastefanos',
     author_email='spapas@gmail.com',
     license='MIT',
-    url='https://github.com/spapas/mailer_server',
+    url='https://github.com/spapas/django-mailer-server-backend',
     zip_safe=False,
     include_package_data=True,
     packages=find_packages(exclude=['tests.*', 'tests',]),


### PR DESCRIPTION
s/mailer-server/django-mailer-server-backend/

It's a trivial change, but without it the link from PyPI to the source repository is broken, so I figured still worth bringing to your attention.

Thanks for sharing your code! :smile: 